### PR TITLE
chore: group dependabot updates and pin actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,19 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
 
-  - package-ecosystem: pip
-    directory: /app
+  - package-ecosystem: "pip"
+    directory: "/app"
     schedule:
-      interval: monthly
+      interval: "monthly"
+    groups:
+      patch:
+        update-types:
+          - "patch"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,5 +6,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: psf/black@stable


### PR DESCRIPTION
## Summary

Standardize Dependabot grouping rules and pin GitHub Actions to commit hashes.

- Add `patch` group (`update-types: ["patch"]`) for non-actions / non-terraform ecosystems so that patch-level updates land in a single PR.
- Group all GitHub Actions into `all-actions` and Terraform providers into `all-providers` (where applicable).
- Pin all GitHub Actions referenced in `.github/workflows/*.yml` to commit hashes using [pinact](https://github.com/suzuki-shunsuke/pinact). The version comment after each hash lets Dependabot continue to bump them.

## Test plan

- [ ] Confirm Dependabot UI accepts the new config (no errors on next scheduled run)
- [ ] Confirm existing workflows still pass